### PR TITLE
fix: update example to modern callback API with errorMessage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ web-build/
 expo-env.d.ts
 
 # Native
+android/
+ios/
 *.orig.*
 *.jks
 *.p8

--- a/app/authorization.tsx
+++ b/app/authorization.tsx
@@ -1,17 +1,15 @@
 import { ENVIRONMENT, SafepayPayerAuthentication } from "@sfpy/react-native";
 
-
 export default function SafepayPayerAuthenticationModal() {
-
     return (
         <SafepayPayerAuthentication
-            environment={ENVIRONMENT.SANDBOX}
-            onCardinalSuccess={data => console.log("onCardinalSuccess", data)}
-            onCardinalError={data => console.log("onCardinalError", data)}
-            onPayerAuthEnrollmentRequired={() => console.log("onPayerAuthEnrollmentRequired")}
-            onPayerAuthEnrollmentFrictionless={data => console.log("onPayerAuthEnrollmentFrictionless", data)}
-            onPayerAuthEnrollmentFailure={data => console.log("onPayerAuthEnrollmentFailure", data)}
+            environment={ENVIRONMENT.DEVELOPMENT}
+            onPayerAuthenticationRequired={() => console.log("onPayerAuthenticationRequired")}
+            onPayerAuthenticationFrictionless={data => console.log("onPayerAuthenticationFrictionless", data)}
+            onPayerAuthenticationSuccess={data => console.log("onPayerAuthenticationSuccess", data)}
+            onPayerAuthenticationFailure={data => console.log("onPayerAuthenticationFailure", data)}
+            onPayerAuthenticationUnavailable={data => console.log("onPayerAuthenticationUnavailable", data.errorMessage)}
             onSafepayError={data => console.log("onSafepayError", data)}
         />
     );
-};
+}


### PR DESCRIPTION
## Summary

- Rewrites `authorization.tsx` from the deprecated callback API to the current one (`onPayerAuthenticationRequired`, `onPayerAuthenticationFrictionless`, `onPayerAuthenticationSuccess`, `onPayerAuthenticationFailure`, `onPayerAuthenticationUnavailable`, `onSafepayError`)
- Shows `data.errorMessage` usage in `onPayerAuthenticationUnavailable`, reflecting the new field added to `PayerAuthenticationData`

## Related PRs

This is part of a fix for the duplicate payer-auth failure callback bug, applied consistently across all Safepay SDKs and examples:

| Repo | PR |
|------|----|
| safepay-drops | https://github.com/getsafepay/safepay-drops/pull/74 |
| safepay-atoms | https://github.com/getsafepay/safepay-atoms/pull/35 |
| android-drops-sdk | https://github.com/getsafepay/android-drops-sdk/pull/1 |
| swift-drops-sdk | https://github.com/getsafepay/swift-drops-sdk/pull/2 |
| sfpy-react-native | https://github.com/getsafepay/sfpy-react-native/pull/11 |
| android-drops-sdk-example | https://github.com/getsafepay/android-drops-sdk-example/pull/1 |
| swift-drops-sdk-example | https://github.com/getsafepay/swift-drops-sdk-example/pull/1 |